### PR TITLE
Upgrade sinatra_auth_github to v2.0.0

### DIFF
--- a/squad_goals.gemspec
+++ b/squad_goals.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'warden-github', '~> 1.1'
-  spec.add_dependency 'sinatra_auth_github', '~> 1.1'
+  spec.add_dependency 'sinatra_auth_github', '~> 2.0'
   spec.add_dependency 'octokit', '~> 4.0'
   spec.add_dependency 'rack-ssl-enforcer', '~> 0.2'
   spec.add_dependency 'dotenv', '~> 2.0'


### PR DESCRIPTION
This allows us to use Sinatra v2.0.

https://github.com/atmos/sinatra_auth_github/compare/v1.2.0...v2.0.0

The driving reason is that Sinatra 1.x depends on Rack 1.x and Rack 1.x has unpatched CVE's.